### PR TITLE
Decrease horizontal padding in mobile navigation

### DIFF
--- a/source/_assets/sass/_navigation.scss
+++ b/source/_assets/sass/_navigation.scss
@@ -5,7 +5,7 @@
     @apply .mb-8;
     @apply .pb-4;
     @apply .pt-8;
-    @apply .px-8;
+    @apply .px-4;
     @apply .shadow;
     @apply .w-auto;
 


### PR DESCRIPTION
# Overview

This pull request decreases the horizontal padding in the mobile responsive navigation. [This also relates Blog starter template pull request.](https://github.com/tightenco/jigsaw-blog-skeleton/pull/20)

## Trello
1. [Decrease the horizontal padding in the mobile navigation](https://trello.com/c/zu0BJmuz/55-decrease-the-horizontal-padding-in-the-mobile-navigation)

### Screenshots 
<img width="904" alt="screen shot 2018-12-17 at 12 02 11 pm" src="https://user-images.githubusercontent.com/487612/50102697-b3fe9f00-01f3-11e9-8c1a-74cbb9ec3e06.png">

☝️ Current horizontal padding on develop branch (staging server).

<img width="927" alt="screen shot 2018-12-17 at 12 03 11 pm" src="https://user-images.githubusercontent.com/487612/50102713-beb93400-01f3-11e9-9d9d-17ddd1ccf5da.png">

☝️ After changes in this pull request.