### PR TITLE
Remove excess flexbox classes

### DIFF
--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -22,8 +22,8 @@
 
     <hr class="block my-8 border lg:hidden">
 
-    <div class="flex flex-col -mx-2 items-center justify-center md:items-start md:flex-row md:-mx-4 md:justify-between">
-        <div class="flex flex-col w-full mb-8 mx-3 px-2 md:w-1/3">
+    <div class="md:flex -mx-2 -mx-4">
+        <div class="mb-8 mx-3 px-2 md:w-1/3">
             <img src="/assets/img/icon-window.svg" class="h-12 w-12" alt="window icon">
 
             <h3 id="intro-laravel" class="text-2xl text-blue-darkest mb-0">Templating with <br>Laravel's Blade engine</h3>
@@ -31,7 +31,7 @@
             <p>Blade is a powerful, simple, and beautiful templating language, and now you can use it for your static sites, not just your Laravel-powered apps.</p>
         </div>
 
-        <div class="flex flex-col w-full mb-8 mx-3 px-2 md:w-1/3">
+        <div class="mb-8 mx-3 px-2 md:w-1/3">
             <img src="/assets/img/icon-terminal.svg" class="h-12 w-12" alt="terminal icon">
 
             <h3 id="intro-markdown" class="text-2xl text-blue-darkest mb-0">Use Markdown for <br>content-driven pages</h3>
@@ -39,7 +39,7 @@
             <p>Markdown is the web’s leading format for writing articles, blog posts, documentation, and more. Jigsaw makes it painless to work with Markdown content.</p>
         </div>
 
-        <div class="flex flex-col w-full mx-3 px-2 md:w-1/3">
+        <div class="mx-3 px-2 md:w-1/3">
             <img src="/assets/img/icon-stack.svg" class="h-12 w-12" alt="stack icon">
 
             <h3 id="intro-mix" class="text-2xl text-blue-darkest mb-0">Compile your assets <br>using Laravel Mix </h3>


### PR DESCRIPTION
# Overview

This pull request fixes some of the overused flexbox classes on the homepage three column grid.

## Trello
1. [Simplify flexbox utility classes from suggested example](https://trello.com/c/3xvrHjFV/73-simplify-flexbox-utility-classes-from-suggested-example)

### Screenshots
<img width="1275" alt="screen shot 2019-01-02 at 12 04 26 pm" src="https://user-images.githubusercontent.com/487612/50602874-9f263a80-0e86-11e9-9c4b-d99e32eb1639.png">
