### PR TITLE
Add DocSearch-content class to documentation container

### DIFF
--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -11,7 +11,7 @@
             @include('_nav.menu', ['items' => $page->navigation])
         </nav>
 
-        <div class="w-full lg:w-3/5 break-words pb-16 lg:pl-4" v-pre>
+        <div class="DocSearch-content w-full lg:w-3/5 break-words pb-16 lg:pl-4" v-pre>
             @yield('content')
         </div>
     </div>


### PR DESCRIPTION
When applying to set up Algolia DocSearch for https://devsnippets.xyz/ this week, I had the following response from them.

![algolia](https://user-images.githubusercontent.com/24735291/66244375-f56b2700-e6ff-11e9-8a65-67e1616ded28.png)

Further information can be found [here](https://community.algolia.com/docsearch/required-configuration.html#use-the-right-classes-as-selectors)

This pull request simply adds the required `DocSearch-content` class to the 'main container of  textual content'.

Feel free to close this if it's not something you want to add, just thought I would PR it while it's fresh in my mind! Cheers 😃
